### PR TITLE
Fix unbounded parallelism

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    freddy (0.3.7)
+    freddy (0.4.0)
       bunny (= 1.6.3)
       hamster (~> 1.0.1.pre.rc3)
       symbolizer

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,12 +5,13 @@ PATH
       bunny (= 1.6.3)
       hamster (~> 1.0.1.pre.rc3)
       symbolizer
+      thread (~> 0.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
     amq-protocol (1.9.2)
-    atomic (1.1.16)
+    atomic (1.1.99)
     bunny (1.6.3)
       amq-protocol (>= 1.9.2)
     coderay (1.1.0)
@@ -37,6 +38,7 @@ GEM
     rspec-support (3.1.2)
     slop (3.6.0)
     symbolizer (0.0.1)
+    thread (0.2.2)
 
 PLATFORMS
   ruby

--- a/README.md
+++ b/README.md
@@ -144,10 +144,13 @@ responder_handler.destroy_destination
 ## Notes about concurrency
 
 The underlying bunny implementation uses 1 responder thread by default. This means that if there is a time-consuming process or a sleep call in a responder then other responders will not receive messages concurrently.
-
-This is especially devious when using `deliver_with_response` in a responder because `deliver_with_response` creates a new anonymous responder which will not receive the response if the parent responder uses a sleep call.
-
-To resolve this problem *freddy* creates separate threads for processing. Read more from <http://rubybunny.info/articles/concurrency.html>.
+To resolve this problem *freddy* uses a thread pool for running concurrent responders.
+The thread pool is shared between *tap_into* and *respond_to* callbacks and the default size is 4.
+The thread pool size can be configured by passing the configuration option *max_concurrency*.
+Note that other configuration options for freddy users 
+such as pool sizes for DB connections need to match or exceed *max_concurrency*
+to avoid running out of resources.
+Read more from <http://rubybunny.info/articles/concurrency.html>.
 
 ## Credits
 

--- a/freddy.gemspec
+++ b/freddy.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "freddy"
-  spec.version       = '0.3.7'
+  spec.version       = '0.4.0'
   spec.authors       = ["Urmas Talimaa"]
   spec.email         = ["urmas.talimaa@gmail.com"]
   spec.description   = %q{Messaging API}

--- a/freddy.gemspec
+++ b/freddy.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bunny", "1.6.3"
   spec.add_dependency "symbolizer"
   spec.add_dependency "hamster", "~> 1.0.1.pre.rc3"
+  spec.add_dependency "thread", "~> 0.2"
 end

--- a/lib/freddy/consumer.rb
+++ b/lib/freddy/consumer.rb
@@ -13,7 +13,7 @@ class Freddy
       @channel, @logger = channel, logger
       @topic_exchange = @channel.topic Freddy::FREDDY_TOPIC_EXCHANGE_NAME
       @consume_thread_pool = consume_thread_pool
-      @dedicated_thread_pool = Thread.pool(1)
+      @dedicated_thread_pool = Thread.pool(1) # used only internally
     end
 
     def consume(destination, options = {}, &block)

--- a/lib/freddy/request.rb
+++ b/lib/freddy/request.rb
@@ -17,9 +17,9 @@ class Freddy
     class EmptyResponder < Exception
     end
 
-    def initialize(channel, logger)
+    def initialize(channel, logger, producer, consumer)
       @channel, @logger = channel, logger
-      @producer, @consumer = Producer.new(channel, logger), Consumer.new(channel, logger)
+      @producer, @consumer = producer, consumer
       @request_map = Hamster.mutable_hash
       @request_manager = RequestManager.new @request_map, @logger
 
@@ -115,7 +115,7 @@ class Freddy
         else
           ensure_response_queue_exists
           @request_manager.start
-          @consumer.consume_from_queue @response_queue do |payload, delivery|
+          @consumer.dedicated_consume @response_queue do |payload, delivery|
             handle_response payload, delivery
           end
           @listening_for_responses = true

--- a/spec/integration/concurrency_spec.rb
+++ b/spec/integration/concurrency_spec.rb
@@ -1,34 +1,36 @@
 require 'spec_helper'
 
 describe 'Concurrency' do
-  let(:freddy) { Freddy.build(logger, config) }
+  let(:freddy1) { Freddy.build(logger, config) }
+  let(:freddy2) { Freddy.build(logger, config) }
+  let(:freddy3) { Freddy.build(logger, config) }
 
-  it 'supports nested calls in #respond_to' do
-    freddy.respond_to 'Concurrency1' do |payload, msg_handler|
+  it 'supports multiple requests in #respond_to' do
+    freddy1.respond_to 'Concurrency1' do |payload, msg_handler|
       begin
-        result = freddy.deliver_with_response 'Concurrency2', msg: 'noop'
-        msg_handler.success(result)
+        freddy1.deliver_with_response 'Concurrency2', msg: 'noop'
+        result2 = freddy1.deliver_with_response 'Concurrency3', msg: 'noop'
+        msg_handler.success(result2)
       rescue Freddy::InvalidRequestError => e
         msg_handler.error(e.response)
       end
     end
 
-    freddy.respond_to 'Concurrency2' do |payload, msg_handler|
+    freddy2.respond_to 'Concurrency2' do |payload, msg_handler|
       begin
-        result = freddy.deliver_with_response 'Concurrency3', msg: 'noop'
-        msg_handler.success(result)
+        msg_handler.success({from: 'Concurrency2'})
       rescue Freddy::InvalidRequestError => e
         msg_handler.error(e.response)
       end
     end
 
-    freddy.respond_to 'Concurrency3' do |payload, msg_handler|
+    freddy3.respond_to 'Concurrency3' do |payload, msg_handler|
       msg_handler.success({from: 'Concurrency3'})
     end
 
     result =
       begin
-        freddy.deliver_with_response 'Concurrency1', msg: 'noop'
+        freddy1.deliver_with_response 'Concurrency1', msg: 'noop'
       rescue Freddy::InvalidRequestError => e
         e.response
       end
@@ -40,18 +42,18 @@ describe 'Concurrency' do
     received1 = false
     received2 = false
 
-    freddy.tap_into 'concurrency.*.queue1' do
-      result = freddy.deliver_with_response 'TapConcurrency', msg: 'noop'
+    freddy1.tap_into 'concurrency.*.queue1' do
+      result = freddy1.deliver_with_response 'TapConcurrency', msg: 'noop'
       expect(result).to eq(from: 'TapConcurrency')
       received1 = true
     end
 
-    freddy.respond_to 'TapConcurrency' do |payload, msg_handler|
+    freddy2.respond_to 'TapConcurrency' do |payload, msg_handler|
       msg_handler.success({from: 'TapConcurrency'})
       received2 = true
     end
 
-    freddy.deliver 'concurrency.q.queue1', msg: 'noop'
+    freddy1.deliver 'concurrency.q.queue1', msg: 'noop'
 
     wait_for { received1 && received2 }
 


### PR DESCRIPTION
Creating new threads forces all thread-local state to be reinitialized.
This means creating new PG connections and AR pools and so on.
Moreover, some requests timing out can lead to an explosion
of parallelism which creates very many threads and as a result of this
also very many file handlers for amqp pipes and user connections (e.g PG).

Therefore it is necessary to bound parallelism while still allowing
unlimited reqres inside a responder.

This can be done by listening for RPC responses on a dedicated thread
and moving consumer threads into a thread pool.