### PR TITLE
Avoid making error messages unique when notifying error reporter

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    freddy (0.4.1)
+    freddy (0.4.2)
       bunny (= 1.6.3)
       hamster (~> 1.0.1.pre.rc3)
       symbolizer
@@ -49,3 +49,6 @@ DEPENDENCIES
   pry
   rake
   rspec
+
+BUNDLED WITH
+   1.10.6

--- a/freddy.gemspec
+++ b/freddy.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "freddy"
-  spec.version       = '0.4.1'
+  spec.version       = '0.4.2'
   spec.authors       = ["Urmas Talimaa"]
   spec.email         = ["urmas.talimaa@gmail.com"]
   spec.description   = %q{Messaging API}

--- a/lib/freddy/request.rb
+++ b/lib/freddy/request.rb
@@ -92,9 +92,8 @@ class Freddy
         @request_map.delete correlation_id
         request[:callback].call payload, delivery
       else
-        message = "Got rpc response for correlation_id #{correlation_id} but there is no requester"
-        @logger.warn message
-        Freddy.notify 'NoRequesterForResponse', message, correlation_id: correlation_id
+        @logger.warn "Got rpc response for correlation_id #{correlation_id} but there is no requester"
+        Freddy.notify 'NoRequesterForResponse', "Got rpc response but there is no requester", correlation_id: correlation_id
       end
     rescue Exception => e
       destination_report = request ? "to #{request[:destination]}" : ''

--- a/lib/freddy/request_manager.rb
+++ b/lib/freddy/request_manager.rb
@@ -32,9 +32,12 @@ class Freddy
     def timeout(correlation_id, request)
       @requests.delete correlation_id
 
-      message = "Request #{correlation_id} timed out waiting response from #{request[:destination]} with timeout #{request[:timeout]}"
-      @logger.warn message
-      Freddy.notify 'RequestTimeout', message, request: correlation_id, destination: request[:destination], timeout: request[:timeout]
+      @logger.warn "Request timed out waiting response from #{request[:destination]}, correlation id #{correlation_id}"
+      Freddy.notify 'RequestTimeout', "Request timed out waiting for response from #{request[:destination]}", {
+        correlation_id: correlation_id,
+        destination: request[:destination],
+        timeout: request[:timeout]
+      }
 
       request[:callback].call({error: 'RequestTimeout', message: 'Timed out waiting for response'}, nil)
     end


### PR DESCRIPTION
Helps to better classify the errors by name.