### PR TITLE
Replace sleep with proper wakeup mechanism

### DIFF
--- a/freddy.gemspec
+++ b/freddy.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   else
     spec.name          = "freddy"
   end
-  spec.version       = '0.4.4'
+  spec.version       = '0.4.5'
   spec.authors       = ["Urmas Talimaa"]
   spec.email         = ["urmas.talimaa@gmail.com"]
   spec.description   = %q{Messaging API}

--- a/spec/freddy/sync_response_container_spec.rb
+++ b/spec/freddy/sync_response_container_spec.rb
@@ -6,7 +6,7 @@ describe Freddy::SyncResponseContainer do
   context 'when timeout' do
     subject { container.wait_for_response(0.01) }
 
-    it 'raises' do
+    it 'raises timeout error' do
       expect { subject }.to raise_error(Timeout::Error, 'execution expired')
     end
   end

--- a/spec/freddy/sync_response_container_spec.rb
+++ b/spec/freddy/sync_response_container_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Freddy::SyncResponseContainer do
+  let(:container) { described_class.new }
+
+  context 'when timeout' do
+    subject { container.wait_for_response(0.01) }
+
+    it 'raises' do
+      expect { subject }.to raise_error(Timeout::Error, 'execution expired')
+    end
+  end
+end


### PR DESCRIPTION
Performance test [deliver_with_response 10K messages] on my local computer:
**before**: `4.920000   2.360000   7.280000 (  6.821925)`
**after**: `4.330000   1.520000   5.850000 (  5.137929)`