### PR TITLE
Configure oj to use strict mode

### DIFF
--- a/freddy.gemspec
+++ b/freddy.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   else
     spec.name          = "freddy"
   end
-  spec.version       = '0.4.6'
+  spec.version       = '0.4.7'
   spec.authors       = ["Urmas Talimaa"]
   spec.email         = ["urmas.talimaa@gmail.com"]
   spec.description   = %q{Messaging API}

--- a/lib/freddy/payload.rb
+++ b/lib/freddy/payload.rb
@@ -23,7 +23,7 @@ class Freddy
 
     class OjAdapter
       def self.parse(payload)
-        Oj.load(payload, symbol_keys: true)
+        Oj.strict_load(payload, symbol_keys: true)
       end
 
       def self.dump(payload)


### PR DESCRIPTION
This is so that strings will stay strings when loaded instead of strings
starting with ':' (a colon) being automatically converted into symbols.