### PR TITLE
Fix race condition in wait_for_response

### DIFF
--- a/lib/freddy/sync_response_container.rb
+++ b/lib/freddy/sync_response_container.rb
@@ -10,37 +10,29 @@ class Freddy
     end
 
     def call(response, delivery)
-      @mutex.synchronize do
-        @response = response
-        @delivery = delivery
-        @resource.signal
+      if response.nil?
+        raise StandardError, 'unexpected nil value for response'
       end
+
+      @response = response
+      @delivery = delivery
+      @mutex.synchronize { @resource.signal }
     end
 
     def wait_for_response(timeout)
-      @mutex.synchronize do
-        @resource.wait(@mutex, timeout) unless response_received?
-      end
+      @mutex.synchronize { @response || @resource.wait(@mutex, timeout) }
 
-      if !response_received?
+      if !@response
         @on_timeout.call
         raise TimeoutError.new(
           error: 'RequestTimeout',
           message: 'Timed out waiting for response'
         )
-      elsif @response.nil?
-        raise StandardError, 'unexpected nil value for response'
       elsif !@delivery || @delivery.type == 'error'
         raise InvalidRequestError.new(@response)
       else
         @response
       end
-    end
-
-    private
-
-    def response_received?
-      defined?(@response)
     end
   end
 end

--- a/lib/freddy/sync_response_container.rb
+++ b/lib/freddy/sync_response_container.rb
@@ -3,9 +3,10 @@ require 'timeout'
 
 class Freddy
   class SyncResponseContainer
-    def initialize
+    def initialize(on_timeout)
       @mutex = Mutex.new
       @resource = ConditionVariable.new
+      @on_timeout = on_timeout
     end
 
     def call(response, delivery)
@@ -14,10 +15,6 @@ class Freddy
         @delivery = delivery
         @resource.signal
       end
-    end
-
-    def on_timeout(&block)
-      @on_timeout = block
     end
 
     def wait_for_response(timeout)

--- a/spec/freddy/sync_response_container_spec.rb
+++ b/spec/freddy/sync_response_container_spec.rb
@@ -18,19 +18,12 @@ describe Freddy::SyncResponseContainer do
     end
   end
 
-  context 'when nil resonse' do
+  context 'when nil response' do
     let(:delivery) { {} }
-
-    before do
-      Thread.new do
-        default_sleep
-        container.call(nil, delivery)
-      end
-    end
 
     it 'raises timeout error' do
       expect {
-        container.wait_for_response(2)
+        container.call(nil, delivery)
       }.to raise_error(StandardError, 'unexpected nil value for response')
     end
   end

--- a/spec/freddy/sync_response_container_spec.rb
+++ b/spec/freddy/sync_response_container_spec.rb
@@ -44,12 +44,20 @@ describe Freddy::SyncResponseContainer do
     let(:delivery) { OpenStruct.new(type: 'success') }
 
     context 'when called after #call' do
+      let(:max_wait_time_in_seconds) { 0.5 }
+
       before do
         container.call(response, delivery)
       end
 
       it 'returns response' do
         expect(container.wait_for_response(timeout)).to eq(response)
+      end
+
+      it 'does not wait for timeout' do
+        expect {
+          container.wait_for_response(timeout)
+        }.to change(Time, :now).by_at_most(max_wait_time_in_seconds)
       end
     end
   end

--- a/spec/freddy/sync_response_container_spec.rb
+++ b/spec/freddy/sync_response_container_spec.rb
@@ -1,11 +1,8 @@
 require 'spec_helper'
 
 describe Freddy::SyncResponseContainer do
-  let(:container) { described_class.new }
-
-  before do
-    container.on_timeout {}
-  end
+  let(:container) { described_class.new(on_timeout) }
+  let(:on_timeout) { Proc.new {} }
 
   context 'when timeout' do
     subject { container.wait_for_response(0.01) }


### PR DESCRIPTION
If the response is already received then just returned it. There's no
reason to wait for resource signal.