### PR TITLE
Add `group` option to Freddy#tap_into

### DIFF
--- a/lib/freddy.rb
+++ b/lib/freddy.rb
@@ -90,6 +90,10 @@ class Freddy
   # @param [String] pattern
   #   the destination pattern. Use `#` wildcard for matching 0 or more words.
   #   Use `*` to match exactly one word.
+  # @param [Hash] options
+  # @option options [String] :group
+  #   only one of the listeners in given group will receive a message. All
+  #   listeners will receive a message if the group is not specified.
   #
   # @yield [message] Yields received message to the block
   #
@@ -99,9 +103,9 @@ class Freddy
   #   freddy.tap_into 'notifications.*' do |message|
   #     puts "Notification showed #{message.inspect}"
   #   end
-  def tap_into(pattern, &callback)
+  def tap_into(pattern, options = {}, &callback)
     @logger.debug "Tapping into messages that match #{pattern}"
-    @tap_into_consumer.consume(pattern, @connection.create_channel, &callback)
+    @tap_into_consumer.consume(pattern, @connection.create_channel, options, &callback)
   end
 
   # Sends a message to given destination

--- a/spec/integration/tap_into_with_group_spec.rb
+++ b/spec/integration/tap_into_with_group_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'hamster/experimental/mutable_set'
+
+describe 'Tapping into with group identifier' do
+  let(:deliverer) { Freddy.build(logger, config) }
+  let(:responder1) { Freddy.build(logger, config) }
+  let(:responder2) { Freddy.build(logger, config) }
+
+  let(:destination)  { random_destination }
+
+  after { [deliverer, responder1, responder2].each(&:close) }
+
+  it 'receives a message once' do
+    msg_counter = Hamster::MutableSet[]
+
+    group_id = arbitrary_id
+    responder1.tap_into(destination, group: group_id) {|msg| msg_counter << 'r1' }
+    responder2.tap_into(destination, group: group_id) {|msg| msg_counter << 'r2' }
+    deliverer.deliver(destination, {})
+
+    default_sleep
+    expect(msg_counter.count).to eq(1)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,10 @@ def random_destination
   SecureRandom.hex
 end
 
+def arbitrary_id
+  SecureRandom.hex
+end
+
 def default_sleep
   sleep 0.05
 end


### PR DESCRIPTION
This allows only one of the `tap_into` listeners in a group to receive a
message.