### PR TITLE
Avoid consuming messages before being able to process them

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,7 @@ responder_handler.shutdown
 
 ## Notes about concurrency
 
-The underlying bunny implementation uses 1 responder thread by default. This means that if there is a time-consuming process or a sleep call in a responder then other responders will not receive messages concurrently.
-To resolve this problem *freddy* uses a thread pool for running concurrent responders.
-The thread pool is shared between *tap_into* and *respond_to* callbacks and the default size is 4.
-The thread pool size can be configured by passing the configuration option *max_concurrency*.
+*freddy* uses a thread pool to run concurrent responders. The thread pool is unique for each *tap_into* and *respond_to* responder. Thread pool size can be configured by passing the configuration option *max_concurrency*. Its default value is 4. e.g. If your application has 2 *respond_to* responders and 1 *tap_into* responder with *max_concurrency* set to 3 then your application may process up to 9 messages in parallel.
 
 
 Note that while it is possible to use *deliver_with_response* inside a *respond_to* block,

--- a/freddy.gemspec
+++ b/freddy.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   else
     spec.name          = "freddy"
   end
-  spec.version       = '0.7.0'
+  spec.version       = '0.7.1'
   spec.authors       = ["Urmas Talimaa"]
   spec.email         = ["urmas.talimaa@gmail.com"]
   spec.description   = %q{Messaging API}

--- a/lib/freddy/adapters.rb
+++ b/lib/freddy/adapters.rb
@@ -24,6 +24,10 @@ class Freddy
         def name
           @queue.name
         end
+
+        def message_count
+          @queue.message_count
+        end
       end
     end
   end

--- a/lib/freddy/consumers/response_consumer.rb
+++ b/lib/freddy/consumers/response_consumer.rb
@@ -3,24 +3,20 @@ class Freddy
     class ResponseConsumer
       def initialize(logger)
         @logger = logger
-        @dedicated_thread_pool = Thread.pool(1)
       end
 
-      def consume(queue, &block)
+      def consume(channel, queue, &block)
         @logger.debug "Consuming messages on #{queue.name}"
-        consumer = queue.subscribe do |delivery|
-          process_message(queue, delivery, &block)
+        queue.subscribe do |delivery|
+          process_message(channel, queue, delivery, &block)
         end
-        ResponderHandler.new(consumer, @dedicated_thread_pool)
       end
 
       private
 
-      def process_message(queue, delivery, &block)
-        @dedicated_thread_pool.process do
-          Consumers.log_receive_event(@logger, queue.name, delivery)
-          block.call(delivery)
-        end
+      def process_message(channel, queue, delivery, &block)
+        Consumers.log_receive_event(@logger, queue.name, delivery)
+        block.call(delivery)
       end
     end
   end

--- a/lib/freddy/delivery.rb
+++ b/lib/freddy/delivery.rb
@@ -1,11 +1,12 @@
 class Freddy
   class Delivery
-    attr_reader :routing_key, :payload
+    attr_reader :routing_key, :payload, :tag
 
-    def initialize(payload, metadata, routing_key)
+    def initialize(payload, metadata, routing_key, tag)
       @payload = payload
       @metadata = metadata
       @routing_key = routing_key
+      @tag = tag
     end
 
     def correlation_id

--- a/lib/freddy/producers/send_and_wait_response_producer.rb
+++ b/lib/freddy/producers/send_and_wait_response_producer.rb
@@ -19,7 +19,7 @@ class Freddy
         @response_queue = @channel.queue("", exclusive: true)
 
         @response_consumer = Consumers::ResponseConsumer.new(@logger)
-        @response_consumer.consume(@response_queue, &method(:handle_response))
+        @response_consumer.consume(@channel, @response_queue, &method(:handle_response))
       end
 
       def produce(destination, payload, timeout_in_seconds:, delete_on_timeout:, **properties)

--- a/spec/freddy/consumers/respond_to_consumer_spec.rb
+++ b/spec/freddy/consumers/respond_to_consumer_spec.rb
@@ -1,24 +1,84 @@
 require 'spec_helper'
 
 describe Freddy::Consumers::RespondToConsumer do
-  let(:consumer) { described_class.new(thread_pool, logger) }
+  let(:consumer) do
+    described_class.new(
+      logger: logger,
+      thread_pool: thread_pool,
+      destination: destination,
+      channel: channel,
+      handler_adapter_factory: msg_handler_adapter_factory
+    )
+  end
 
-  let(:connection)  { Freddy::Adapters.determine.connect(config) }
-  let(:thread_pool) { Thread.pool(1) }
+  let(:connection) { Freddy::Adapters.determine.connect(config) }
   let(:destination) { random_destination }
-  let(:payload)     { {pay: 'load'} }
-  let(:msg_handler) { double }
+  let(:payload) { {pay: 'load'} }
+  let(:msg_handler_adapter_factory) { double(for: msg_handler_adapter) }
+  let(:msg_handler_adapter) { Freddy::MessageHandlerAdapters::NoOpHandler.new }
+  let(:prefetch_buffer_size) { 2 }
+  let(:thread_pool) { Thread.pool(prefetch_buffer_size) }
 
   after do
     connection.close
   end
 
-  it "doesn't call passed block without any messages" do
-    consumer.consume destination, connection.create_channel, msg_handler do
-      @message_received = true
-    end
-    default_sleep
+  context 'when no messages' do
+    let(:channel) { connection.create_channel }
 
-    expect(@message_received).to be_falsy
+    it "doesn't call passed block" do
+      consumer.consume do
+        @message_received = true
+      end
+      default_sleep
+
+      expect(@message_received).to be_falsy
+    end
+  end
+
+  context 'when thread pool is full' do
+    let(:prefetch_buffer_size) { 1 }
+    let(:msg_count) { prefetch_buffer_size + 1 }
+    let(:channel) { connection.create_channel(prefetch: prefetch_buffer_size) }
+    let(:mutex) { Mutex.new }
+    let(:consume_lock) { ConditionVariable.new }
+    let(:queue) { channel.queue(destination) }
+
+    after do
+      # Release the final queued message before finishing the test to avoid
+      # bunny warnings.
+      process_message
+    end
+
+    it 'does not consume more messages' do
+      consumer.consume do
+        wait_until_released
+      end
+
+      msg_count.times { deliver_message }
+
+      sleep default_sleep
+      expect(queue.message_count).to eq(msg_count - prefetch_buffer_size)
+
+      process_message
+      expect(queue.message_count).to eq(0)
+    end
+
+    def process_message
+      release_consume_lock
+      sleep default_sleep
+    end
+
+    def deliver_message
+      channel.default_exchange.publish('{}', routing_key: destination)
+    end
+
+    def wait_until_released
+      mutex.synchronize { consume_lock.wait(mutex) }
+    end
+
+    def release_consume_lock
+      mutex.synchronize { consume_lock.broadcast }
+    end
   end
 end

--- a/spec/freddy/responder_handler_spec.rb
+++ b/spec/freddy/responder_handler_spec.rb
@@ -13,12 +13,12 @@ describe Freddy::ResponderHandler do
       count = 0
 
       consumer_handler = freddy.respond_to destination do
-        sleep 0.1
+        sleep 0.3
         count += 1
       end
       deliver
 
-      sleep 0.05
+      sleep 0.15
       consumer_handler.shutdown
 
       expect(count).to eq(1)


### PR DESCRIPTION
Previously we were taking all messages using Queue#subscribe and then
using a thread pool to process them. It is more useful to keep the
messages that cannot be processed yet in the queue. This allows adding
new consumers that can start processing them.

Prefetch value tells rabbitmq how many messages can consumers on a
channel be given at a time (before they have to acknowledge or reject
one of the earlier received messages).
