### PR TITLE
Require securerandom in main freddy file

### DIFF
--- a/freddy.gemspec
+++ b/freddy.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   else
     spec.name          = "freddy"
   end
-  spec.version       = '0.7.1'
+  spec.version       = '0.7.2'
   spec.authors       = ["Salemove TechMovers"]
   spec.email         = ["techmovers@salemove.com"]
   spec.description   = %q{Messaging API}

--- a/lib/freddy.rb
+++ b/lib/freddy.rb
@@ -1,5 +1,6 @@
 require 'json'
 require 'thread/pool'
+require 'securerandom'
 
 Dir[File.dirname(__FILE__) + '/freddy/*.rb'].each(&method(:require))
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,7 +12,6 @@ SimpleCov.start do
 end
 
 require 'pry'
-require 'securerandom'
 require 'freddy'
 require 'logger'
 require 'hamster/experimental/mutable_set'


### PR DESCRIPTION
Previously tests required it themselves and the library expected it is already required by the client app. This is not always the case. Making it explicitly required.