### PR TITLE
Serialize time objects

### DIFF
--- a/freddy.gemspec
+++ b/freddy.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   else
     spec.name          = "freddy"
   end
-  spec.version       = '0.7.2'
+  spec.version       = '1.0.0'
   spec.authors       = ["Salemove TechMovers"]
   spec.email         = ["techmovers@salemove.com"]
   spec.description   = %q{Messaging API}

--- a/lib/freddy/payload.rb
+++ b/lib/freddy/payload.rb
@@ -27,7 +27,7 @@ class Freddy
       end
 
       def self.dump(payload)
-        Oj.dump(payload, mode: :compat)
+        Oj.dump(payload, mode: :compat, time_format: :xmlschema)
       end
     end
 
@@ -39,7 +39,21 @@ class Freddy
       end
 
       def self.dump(payload)
-        JSON.dump(payload)
+        JSON.dump(serialize_time_objects(payload))
+      end
+
+      def self.serialize_time_objects(object)
+        if object.is_a?(Hash)
+          object.reduce({}) do |hash, (key, value)|
+            hash.merge(key => serialize_time_objects(value))
+          end
+        elsif object.is_a?(Array)
+          object.map(&method(:serialize_time_objects))
+        elsif object.is_a?(Time) || object.is_a?(Date)
+          object.iso8601
+        else
+          object
+        end
       end
     end
   end

--- a/spec/freddy/payload_spec.rb
+++ b/spec/freddy/payload_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+describe Freddy::Payload do
+  describe '#dump' do
+    it 'serializes time objects as iso8601 format strings' do
+      expect(dump(time: Time.utc(2016, 1, 4, 20, 18)))
+        .to eq('{"time":"2016-01-04T20:18:00Z"}')
+    end
+
+    it 'serializes time objects in an array as iso8601 format strings' do
+      expect(dump(time: [Time.utc(2016, 1, 4, 20, 18)]))
+        .to eq('{"time":["2016-01-04T20:18:00Z"]}')
+    end
+
+    it 'serializes time objects in a nested hash as iso8601 format strings' do
+      expect(dump(x: {time: Time.utc(2016, 1, 4, 20, 18)}))
+        .to eq('{"x":{"time":"2016-01-04T20:18:00Z"}}')
+    end
+
+    it 'serializes date objects as iso8601 format strings' do
+      expect(dump(date: Date.new(2016, 1, 4)))
+        .to eq('{"date":"2016-01-04"}')
+    end
+
+    it 'serializes date objects in an array as iso8601 format strings' do
+      expect(dump(date: [Date.new(2016, 1, 4)]))
+        .to eq('{"date":["2016-01-04"]}')
+    end
+
+    it 'serializes date objects in a nested hash as iso8601 format strings' do
+      expect(dump(x: {date: Date.new(2016, 1, 4)}))
+        .to eq('{"x":{"date":"2016-01-04"}}')
+    end
+
+    it 'serializes datetime objects as iso8601 format strings' do
+      expect(dump(datetime: DateTime.new(2016, 1, 4, 20, 18)))
+        .to eq('{"datetime":"2016-01-04T20:18:00+00:00"}')
+    end
+
+    it 'serializes datetime objects in an array as iso8601 format strings' do
+      expect(dump(datetime: [DateTime.new(2016, 1, 4, 20, 18)]))
+        .to eq('{"datetime":["2016-01-04T20:18:00+00:00"]}')
+    end
+
+    it 'serializes datetime objects in a nested hash as iso8601 format strings' do
+      expect(dump(x: {datetime: DateTime.new(2016, 1, 4, 20, 18)}))
+        .to eq('{"x":{"datetime":"2016-01-04T20:18:00+00:00"}}')
+    end
+
+    def dump(payload)
+      described_class.dump(payload)
+    end
+  end
+end


### PR DESCRIPTION
json lib serializes time objects as:
```
2.4.0 :007 > puts JSON.dump(x: Time.now)
{"x":"2017-01-30 13:43:21 +0200"}
```

Oj with compat mode serializes it as:
```
puts Oj.dump({x: Time.now}, mode: :compat)
{"x":1485776878.255169415e7200}
```

Neither of them are good to send over wire. Use iso8601 format
instead.

Changing mri ruby was done by adding `time_format: :xmlschema` to Oj.
Changing jruby was more complicated because its json lib does not
support time format flags.