### PR TITLE
Limit timestamps precision when serializing objects with Oj

### DIFF
--- a/freddy.gemspec
+++ b/freddy.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   else
     spec.name          = "freddy"
   end
-  spec.version       = '1.0.0'
+  spec.version       = '1.0.1'
   spec.authors       = ["Salemove TechMovers"]
   spec.email         = ["techmovers@salemove.com"]
   spec.description   = %q{Messaging API}

--- a/lib/freddy/payload.rb
+++ b/lib/freddy/payload.rb
@@ -22,12 +22,15 @@ class Freddy
     end
 
     class OjAdapter
+      PARSE_OPTIONS = { symbol_keys: true }
+      DUMP_OPTIONS = { mode: :compat, time_format: :xmlschema, second_precision: 6 }
+
       def self.parse(payload)
-        Oj.strict_load(payload, symbol_keys: true)
+        Oj.strict_load(payload, PARSE_OPTIONS)
       end
 
       def self.dump(payload)
-        Oj.dump(payload, mode: :compat, time_format: :xmlschema)
+        Oj.dump(payload, DUMP_OPTIONS)
       end
     end
 


### PR DESCRIPTION
Precision 6 has been chosen because PostgreSQL also stores timestamps with
6 digits after point. This should fix issues with serialization of ActiveRecord
timestamp attributes.