### PR TITLE
Remove has_required_fields? from TraceCarrier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ gem 'rspec'
 gem 'pry'
 gem 'codeclimate-test-reporter'
 gem 'hamster', '~> 3.0'
-gem 'logasm-tracer', '0.2.0'
+gem 'logasm-tracer', '0.2.2'
 
 gemspec

--- a/freddy.gemspec
+++ b/freddy.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   else
     spec.name          = "freddy"
   end
-  spec.version       = '1.3.0'
+  spec.version       = '1.3.1'
   spec.authors       = ["Salemove TechMovers"]
   spec.email         = ["techmovers@salemove.com"]
   spec.description   = %q{Messaging API}

--- a/lib/freddy/delivery.rb
+++ b/lib/freddy/delivery.rb
@@ -24,7 +24,7 @@ class Freddy
     def build_trace(operation_name, tags: {}, force_follows_from: false)
       carrier = TraceCarrier.new(@metadata)
       parent =
-        if carrier.has_required_fields? && expecting_response? && !force_follows_from
+        if expecting_response? && !force_follows_from
           OpenTracing.global_tracer.extract(OpenTracing::FORMAT_TEXT_MAP, carrier)
         else
           nil

--- a/lib/freddy/trace_carrier.rb
+++ b/lib/freddy/trace_carrier.rb
@@ -22,9 +22,5 @@ class Freddy
           .map {|key, value| [key.sub(/x-trace-/, ''), value]}
       ].each(&block)
     end
-
-    def has_required_fields?
-      self['trace-id'] && self['parent-id'] && self['span-id']
-    end
   end
 end

--- a/spec/integration/logging_spec.rb
+++ b/spec/integration/logging_spec.rb
@@ -14,6 +14,7 @@ describe 'Logging with Logasm::Tracer' do
 
     before do
       freddy.respond_to(destination) do |payload, msg_handler|
+        sleep 0.1 # emulate some processing
         msg_handler.success({})
       end
     end
@@ -49,6 +50,7 @@ describe 'Logging with Logasm::Tracer' do
 
     before do
       freddy.respond_to(destination) do |payload, msg_handler|
+        sleep 0.1 # emulate some processing
         msg_handler.success({
           trace_initiator: {},
           current_receiver: freddy.deliver_with_response(destination2, {})
@@ -56,6 +58,7 @@ describe 'Logging with Logasm::Tracer' do
       end
 
       freddy2.respond_to(destination2) do |payload, msg_handler|
+        sleep 0.1 # emulate some processing
         msg_handler.success({})
       end
     end

--- a/spec/integration/tracing_spec.rb
+++ b/spec/integration/tracing_spec.rb
@@ -8,38 +8,6 @@ describe 'Tracing' do
   before { OpenTracing.global_tracer = tracer }
   after { OpenTracing.global_tracer = nil }
 
-  context 'when receiving an untraced request' do
-    let(:freddy) { Freddy.build(logger, config) }
-    let(:destination) { random_destination }
-
-    before do
-      freddy.respond_to(destination) do |payload, msg_handler|
-        msg_handler.success({
-          trace_id: Freddy.trace.context.trace_id,
-          parent_id: Freddy.trace.context.parent_id,
-          span_id: Freddy.trace.context.span_id
-        })
-      end
-    end
-
-    after { freddy.close }
-
-    it 'has generated trace_id' do
-      response = freddy.deliver_with_response(destination, {})
-      expect(response.fetch(:trace_id)).to_not be_nil
-    end
-
-    it 'has no parent_id' do
-      response = freddy.deliver_with_response(destination, {})
-      expect(response.fetch(:parent_id)).to be_nil
-    end
-
-    it 'has generated span_id' do
-      response = freddy.deliver_with_response(destination, {})
-      expect(response.fetch(:span_id)).to_not be_nil
-    end
-  end
-
   context 'when receiving a traced request' do
     let(:freddy) { Freddy.build(logger, config) }
     let(:freddy2) { Freddy.build(logger, config) }


### PR DESCRIPTION
This is not freddy job. The tracer client must take care of it.