### PR TITLE
Upgrade oj to ~> 3.6

### DIFF
--- a/freddy.gemspec
+++ b/freddy.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
               else
                 'freddy'
               end
-  spec.version       = '1.4.2'
+  spec.version       = '1.5.0'
   spec.authors       = ['Salemove TechMovers']
   spec.email         = ['techmovers@salemove.com']
   spec.description   = 'Messaging API'

--- a/freddy.gemspec
+++ b/freddy.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
     spec.add_dependency 'symbolizer'
   else
     spec.add_dependency 'bunny', '~> 2.11'
-    spec.add_dependency 'oj', '~> 2.13'
+    spec.add_dependency 'oj', '~> 3.6'
   end
 
   spec.add_dependency 'opentracing', '~> 0.4'

--- a/lib/freddy/payload.rb
+++ b/lib/freddy/payload.rb
@@ -25,7 +25,7 @@ class Freddy
 
     class OjAdapter
       PARSE_OPTIONS = { symbol_keys: true }.freeze
-      DUMP_OPTIONS = { mode: :compat, time_format: :xmlschema, second_precision: 6 }.freeze
+      DUMP_OPTIONS = { mode: :custom, time_format: :xmlschema, second_precision: 6 }.freeze
 
       def self.parse(payload)
         Oj.strict_load(payload, PARSE_OPTIONS)


### PR DESCRIPTION
Oj changelog: https://github.com/ohler55/oj/blob/master/CHANGELOG.md

The previous version didn't work with ruby 2.5. It does not seem that v2
will be changed to support it. v3 however supports ruby 2.5 just fine.