### PR TITLE
Allow specifying durable queues for #tap_into

### DIFF
--- a/lib/freddy.rb
+++ b/lib/freddy.rb
@@ -114,6 +114,12 @@ class Freddy
   # @option options [Boolean] :durable
   #   Should the consumer queue be durable? Default is `false`. This option can
   #   be used only in combination with option `:group`.
+  # @option options [Boolean] :on_exception
+  #   Defines consumer's behaviour when the callback fails to process a message
+  #   and raises an exception. Can be one of `:ack`, `:reject` or `:requeue`.
+  #   `:ack` simply acknowledges the message and re-raises the exception. `:reject`
+  #   rejects the message without requeueing it. `:requeue` rejects the message with
+  #   `requeue` flag.
   #
   # @yield [message] Yields received message to the block
   #

--- a/lib/freddy.rb
+++ b/lib/freddy.rb
@@ -111,6 +111,9 @@ class Freddy
   # @option options [String] :group
   #   only one of the listeners in given group will receive a message. All
   #   listeners will receive a message if the group is not specified.
+  # @option options [Boolean] :durable
+  #   Should the consumer queue be durable? Default is `false`. This option can
+  #   be used only in combination with option `:group`.
   #
   # @yield [message] Yields received message to the block
   #

--- a/lib/freddy/adapters/bunny_adapter.rb
+++ b/lib/freddy/adapters/bunny_adapter.rb
@@ -34,7 +34,7 @@ class Freddy
           @channel = channel
         end
 
-        def_delegators :@channel, :topic, :default_exchange, :consumers, :acknowledge
+        def_delegators :@channel, :topic, :default_exchange, :consumers, :acknowledge, :reject
 
         def queue(*args)
           Queue.new(@channel.queue(*args))

--- a/lib/freddy/adapters/march_hare_adapter.rb
+++ b/lib/freddy/adapters/march_hare_adapter.rb
@@ -33,7 +33,7 @@ class Freddy
           @channel = channel
         end
 
-        def_delegators :@channel, :topic, :default_exchange, :consumers, :acknowledge
+        def_delegators :@channel, :topic, :default_exchange, :consumers, :acknowledge, :reject
 
         def queue(*args)
           Queue.new(@channel.queue(*args))

--- a/lib/freddy/consumers/tap_into_consumer.rb
+++ b/lib/freddy/consumers/tap_into_consumer.rb
@@ -12,6 +12,8 @@ class Freddy
         @pattern = pattern
         @channel = channel
         @options = options
+
+        raise 'Do not use durable queues without specifying a group' if durable? && !group
       end
 
       def consume(&block)
@@ -28,11 +30,10 @@ class Freddy
 
       def create_queue
         topic_exchange = @channel.topic(Freddy::FREDDY_TOPIC_EXCHANGE_NAME)
-        group = @options.fetch(:group, nil)
 
         if group
           @channel
-            .queue("groups.#{group}")
+            .queue("groups.#{group}", durable: durable?)
             .bind(topic_exchange, routing_key: @pattern)
         else
           @channel
@@ -59,6 +60,14 @@ class Freddy
             scope.close
           end
         end
+      end
+
+      def group
+        @options.fetch(:group, nil)
+      end
+
+      def durable?
+        @options.fetch(:durable, false)
       end
     end
   end

--- a/spec/integration/tap_into_with_group_spec.rb
+++ b/spec/integration/tap_into_with_group_spec.rb
@@ -26,4 +26,18 @@ describe 'Tapping into with group identifier' do
     default_sleep
     expect(msg_counter.count).to eq(1)
   end
+
+  it 'can requeue message on exception' do
+    counter = 0
+
+    responder1.tap_into(destination, group: arbitrary_id, on_exception: :requeue) do
+      counter += 1
+      raise 'error' if counter == 1
+    end
+
+    deliverer.deliver(destination, {})
+
+    wait_for { counter == 2 }
+    expect(counter).to eq(2)
+  end
 end

--- a/spec/integration/tap_into_with_group_spec.rb
+++ b/spec/integration/tap_into_with_group_spec.rb
@@ -10,6 +10,11 @@ describe 'Tapping into with group identifier' do
 
   after { [deliverer, responder1, responder2].each(&:close) }
 
+  it 'raises an exception if option :durable is provided without group' do
+    expect { responder1.tap_into(destination, durable: true) }
+      .to raise_error(RuntimeError)
+  end
+
   it 'receives a message once' do
     msg_counter = Hamster::MutableSet[]
 


### PR DESCRIPTION
Also, allow requeueing faulty messages in #tap_into.

These two features may be useful to create reliable consumers (e.g. faulty message can be requeued on exception, queues can survive server crash).