### PR TITLE
Start a new trace when receiving a broadcast

### DIFF
--- a/lib/freddy/delivery.rb
+++ b/lib/freddy/delivery.rb
@@ -60,7 +60,7 @@ class Freddy
         OpenTelemetry::SemanticConventions::Trace::MESSAGING_DESTINATION => @exchange,
         OpenTelemetry::SemanticConventions::Trace::MESSAGING_DESTINATION_KIND => destination_kind,
         OpenTelemetry::SemanticConventions::Trace::MESSAGING_RABBITMQ_ROUTING_KEY => @routing_key,
-        OpenTelemetry::SemanticConventions::Trace::MESSAGING_OPERATION => 'receive'
+        OpenTelemetry::SemanticConventions::Trace::MESSAGING_OPERATION => 'process'
       }
 
       # There's no correlation_id when a message was sent using

--- a/lib/freddy/delivery.rb
+++ b/lib/freddy/delivery.rb
@@ -35,12 +35,11 @@ class Freddy
         links = []
         links << OpenTelemetry::Trace::Link.new(producer_span_context) if producer_span_context.valid?
 
-        # In general we should start a new trace here and just link two traces
-        # together. But Zipkin (which we currently use) doesn't support links.
-        # So even though the root trace could finish before anything here
-        # starts executing, we'll continue with the root trace here as well.
-        OpenTelemetry::Context.with_current(producer_context) do
+        root_span = Freddy.tracer.start_root_span(name, attributes: span_attributes, links: links, kind: kind)
+        OpenTelemetry::Trace.with_span(root_span) do
           Freddy.tracer.in_span(name, attributes: span_attributes, links: links, kind: kind, &block)
+        ensure
+          root_span.finish
         end
       else
         OpenTelemetry::Context.with_current(producer_context) do

--- a/lib/freddy/version.rb
+++ b/lib/freddy/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Freddy
-  VERSION = '2.1.0'
+  VERSION = '2.2.0'
 end


### PR DESCRIPTION
RPC still uses the same trace, but broadcasts (Freddy#deliver) now create
new traces but we still store the original trace link for observability.

I previously went against the spec because Zipkin doesn't support links. 
But we're likely going to replace Zipkin and it's better to follow the 
OpenTelemetry spec.