### PR TITLE
Explicitly require forwardable

### DIFF
--- a/lib/freddy/adapters/bunny_adapter.rb
+++ b/lib/freddy/adapters/bunny_adapter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'bunny'
+require 'forwardable'
 
 class Freddy
   module Adapters

--- a/lib/freddy/version.rb
+++ b/lib/freddy/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Freddy
-  VERSION = '2.2.0'
+  VERSION = '2.2.1'
 end


### PR DESCRIPTION
This is usually present because some other gem loads it as well. In one of
our microservices however no other depdenecy required it. Requiring freddy
failed with:

```
uninitialized constant Freddy::Adapters::BunnyAdapter::Channel::Forwardable
```