### PR TITLE
Do not create duplicate spans

### DIFF
--- a/lib/freddy/delivery.rb
+++ b/lib/freddy/delivery.rb
@@ -36,8 +36,9 @@ class Freddy
         links << OpenTelemetry::Trace::Link.new(producer_span_context) if producer_span_context.valid?
 
         root_span = Freddy.tracer.start_root_span(name, attributes: span_attributes, links: links, kind: kind)
+
         OpenTelemetry::Trace.with_span(root_span) do
-          Freddy.tracer.in_span(name, attributes: span_attributes, links: links, kind: kind, &block)
+          block.call
         ensure
           root_span.finish
         end

--- a/lib/freddy/delivery.rb
+++ b/lib/freddy/delivery.rb
@@ -25,7 +25,7 @@ class Freddy
     end
 
     def in_span(force_follows_from: false, &block)
-      name = "#{@exchange}.#{@routing_key} receive"
+      name = "#{@exchange}.#{@routing_key} process"
       kind = OpenTelemetry::Trace::SpanKind::CONSUMER
       producer_context = OpenTelemetry.propagation.extract(@metadata[:headers] || {})
 

--- a/lib/freddy/version.rb
+++ b/lib/freddy/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Freddy
-  VERSION = '2.2.1'
+  VERSION = '2.2.2'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,13 @@ require 'freddy'
 require 'logger'
 require 'hamster/experimental/mutable_set'
 
+SPAN_EXPORTER = OpenTelemetry::SDK::Trace::Export::InMemorySpanExporter.new
+span_processor = OpenTelemetry::SDK::Trace::Export::SimpleSpanProcessor.new(SPAN_EXPORTER)
+
+OpenTelemetry::SDK.configure do |c|
+  c.add_span_processor(span_processor)
+end
+
 Thread.abort_on_exception = true
 
 RSpec.configure do |config|


### PR DESCRIPTION
Receiving a broadcast had a bug. It created a root span and then used
`in_span` which creates a new span with same content, causing a duplicate
span.