### PR TITLE
Fix propagating span ID

### DIFF
--- a/lib/freddy/producers/reply_producer.rb
+++ b/lib/freddy/producers/reply_producer.rb
@@ -22,7 +22,7 @@ class Freddy
           routing_key: routing_key,
           content_type: CONTENT_TYPE
         )
-        Tracing.inject_tracing_information_to_properties!(properties)
+        Tracing.inject_tracing_information_to_properties!(properties, span)
 
         @exchange.publish Payload.dump(payload), properties
       ensure

--- a/lib/freddy/producers/send_and_forget_producer.rb
+++ b/lib/freddy/producers/send_and_forget_producer.rb
@@ -18,7 +18,7 @@ class Freddy
           routing_key: routing_key,
           content_type: CONTENT_TYPE
         )
-        Tracing.inject_tracing_information_to_properties!(properties)
+        Tracing.inject_tracing_information_to_properties!(properties, span)
 
         json_payload = Freddy::Encoding.compress(
           Payload.dump(payload),

--- a/lib/freddy/producers/send_and_wait_response_producer.rb
+++ b/lib/freddy/producers/send_and_wait_response_producer.rb
@@ -49,7 +49,7 @@ class Freddy
           correlation_id: correlation_id, reply_to: @response_queue.name,
           mandatory: true, type: 'request'
         )
-        Tracing.inject_tracing_information_to_properties!(properties)
+        Tracing.inject_tracing_information_to_properties!(properties, span)
 
         # Connection adapters handle thread safety for #publish themselves. No
         # need to lock this.

--- a/lib/freddy/tracing.rb
+++ b/lib/freddy/tracing.rb
@@ -39,9 +39,10 @@ class Freddy
       end
     end
 
-    def self.inject_tracing_information_to_properties!(properties)
+    def self.inject_tracing_information_to_properties!(properties, span)
+      context = OpenTelemetry::Trace.context_with_span(span)
       properties[:headers] ||= {}
-      OpenTelemetry.propagation.inject(properties[:headers])
+      OpenTelemetry.propagation.inject(properties[:headers], context: context)
     end
   end
 end

--- a/lib/freddy/version.rb
+++ b/lib/freddy/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Freddy
-  VERSION = '2.2.3'
+  VERSION = '2.2.4'
 end

--- a/spec/integration/tracing_spec.rb
+++ b/spec/integration/tracing_spec.rb
@@ -147,10 +147,13 @@ describe 'Tracing' do
                     /freddy-topic\.\w+ process/
                   ])
 
+      send_span = exporter.finished_spans.find { |span| span.name =~ /\.\w+ send/ }
+
       expect(@deliver_span.fetch(:trace_id)).not_to eq(initiator_span.fetch(:trace_id))
 
       link = @deliver_span.fetch(:links)[0]
       expect(link.span_context.trace_id).to eq(initiator_span.fetch(:trace_id))
+      expect(link.span_context.span_id).to eq(send_span.span_id)
     end
   end
 


### PR DESCRIPTION
`span_for_produce` method creates a new span using `start_span` call. This
method doesn't automatically change the OpenTelemetry current context like
`in_span` and `with_span`. This meant that the
`propagation.inject` used a wrong span. The traces still included all the
spans but the ordering was incorrect because the receiver spans had wrong
parent spans.