### PR TITLE
Change tap_into span relationship to parent-child

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,5 +27,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
+        cache-version: 1
     - name: Run lint & tests
       run: bundle exec rake

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .bundle/
-Gemfile.lock
 pkg
 .tags
 .tags1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,102 @@
+PATH
+  remote: .
+  specs:
+    freddy (2.3.0)
+      bunny (~> 2.11)
+      oj (~> 3.6)
+      opentelemetry-api (~> 1.0.0.rc3)
+      opentelemetry-semantic_conventions (~> 1.0)
+      thread (~> 0.1)
+      zlib (~> 1.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    amq-protocol (2.3.2)
+    ast (2.4.2)
+    bunny (2.19.0)
+      amq-protocol (~> 2.3, >= 2.3.1)
+      sorted_set (~> 1, >= 1.0.2)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.9)
+    diff-lcs (1.4.4)
+    hamster (3.0.0)
+      concurrent-ruby (~> 1.0)
+    method_source (1.0.0)
+    oj (3.13.2)
+    opentelemetry-api (1.0.0.rc3)
+    opentelemetry-common (0.19.1)
+      opentelemetry-api (~> 1.0.0.rc3)
+    opentelemetry-instrumentation-base (0.18.2)
+      opentelemetry-api (~> 1.0.0.rc3)
+    opentelemetry-sdk (1.0.0.rc3)
+      opentelemetry-api (~> 1.0.0.rc3)
+      opentelemetry-common (~> 0.19.1)
+      opentelemetry-instrumentation-base (~> 0.18.2)
+      opentelemetry-semantic_conventions
+    opentelemetry-semantic_conventions (1.6.0)
+      opentelemetry-api (~> 1.0.0.rc3)
+    parallel (1.20.1)
+    parser (3.0.2.0)
+      ast (~> 2.4.1)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rainbow (3.0.0)
+    rake (13.0.6)
+    rbtree (0.4.4)
+    regexp_parser (2.1.1)
+    rexml (3.2.5)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.1)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.2)
+    rubocop (1.19.0)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.9.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.10.0)
+      parser (>= 3.0.1.1)
+    rubocop-rspec (2.4.0)
+      rubocop (~> 1.0)
+      rubocop-ast (>= 1.1.0)
+    ruby-progressbar (1.11.0)
+    set (1.0.1)
+    sorted_set (1.0.3)
+      rbtree
+      set (~> 1.0)
+    thread (0.2.2)
+    unicode-display_width (2.0.0)
+    zlib (1.1.0)
+
+PLATFORMS
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  bundler
+  freddy!
+  hamster (~> 3.0)
+  opentelemetry-sdk (~> 1.0.0.rc3)
+  pry
+  rake
+  rspec
+  rubocop (~> 1.19)
+  rubocop-rspec (~> 2.4)
+
+BUNDLED WITH
+   2.2.27

--- a/lib/freddy/consumers/tap_into_consumer.rb
+++ b/lib/freddy/consumers/tap_into_consumer.rb
@@ -47,7 +47,7 @@ class Freddy
 
       def process_message(_queue, delivery)
         @consume_thread_pool.process do
-          delivery.in_span(force_follows_from: true) do
+          delivery.in_span do
             yield delivery.payload, delivery.routing_key
             @channel.acknowledge(delivery.tag)
           end

--- a/lib/freddy/version.rb
+++ b/lib/freddy/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Freddy
-  VERSION = '2.2.4'
+  VERSION = '2.3.0'
 end

--- a/spec/integration/tracing_spec.rb
+++ b/spec/integration/tracing_spec.rb
@@ -132,10 +132,8 @@ describe 'Tracing' do
       freddy.close
     end
 
-    it 'creates a new trace and links it with the sender' do
-      initiator_span = nil
+    it 'continues the existing trace' do
       Freddy.tracer.in_span('test') do
-        initiator_span = current_span_attributes
         freddy.deliver(destination, {})
       end
       wait_for { @deliver_span }
@@ -147,13 +145,7 @@ describe 'Tracing' do
                     /freddy-topic\.\w+ process/
                   ])
 
-      send_span = exporter.finished_spans.find { |span| span.name =~ /\.\w+ send/ }
-
-      expect(@deliver_span.fetch(:trace_id)).not_to eq(initiator_span.fetch(:trace_id))
-
-      link = @deliver_span.fetch(:links)[0]
-      expect(link.span_context.trace_id).to eq(initiator_span.fetch(:trace_id))
-      expect(link.span_context.span_id).to eq(send_span.span_id)
+      expect(exporter.finished_spans.map(&:trace_id).uniq.count).to eq(1)
     end
   end
 


### PR DESCRIPTION
I initially used [Link][1] relationship for `Freddy#tap_into`. But many
vendors (including the one we use) don't really support it. After
re-reading the documentation and also looking [an example][2] it seems that
using Parent-Child relationship makes more sense here.

Some libraries also provide an option `propagation_style` to switch between
the two. In this case I don't think we need/should do that.

[1]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/overview.md#links-between-spans
[2]: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/messaging.md#topic-with-multiple-consumers