### PR TITLE
Replace thread gem with concurrent-ruby gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'hamster', '~> 3.0'
 gem 'opentelemetry-sdk', '~> 1.0.0.rc3'
 gem 'pry'
 gem 'rspec'
-gem 'rubocop', '~> 1.19'
+gem 'rubocop', '~> 1.30'
 gem 'rubocop-rspec', '~> 2.4'
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,10 +3,10 @@ PATH
   specs:
     freddy (2.4.0)
       bunny (~> 2.11)
+      concurrent-ruby (~> 1.0)
       oj (~> 3.6)
       opentelemetry-api (~> 1.0.0.rc3)
       opentelemetry-semantic_conventions (~> 1.0)
-      thread (~> 0.1)
       zlib (~> 1.1)
 
 GEM
@@ -79,7 +79,6 @@ GEM
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
-    thread (0.2.2)
     unicode-display_width (2.0.0)
     zlib (1.1.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    freddy (2.4.0)
+    freddy (2.5.0.pre.rc.1)
       bunny (~> 2.11)
       concurrent-ruby (~> 1.0)
       oj (~> 3.6)
@@ -23,7 +23,7 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
-    oj (3.13.11)
+    oj (3.13.14)
     opentelemetry-api (1.0.0.rc3)
     opentelemetry-common (0.19.1)
       opentelemetry-api (~> 1.0.0.rc3)
@@ -36,16 +36,16 @@ GEM
       opentelemetry-semantic_conventions
     opentelemetry-semantic_conventions (1.6.0)
       opentelemetry-api (~> 1.0.0.rc3)
-    parallel (1.20.1)
-    parser (3.0.2.0)
+    parallel (1.22.1)
+    parser (3.1.2.0)
       ast (~> 2.4.1)
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    rainbow (3.0.0)
+    rainbow (3.1.1)
     rake (13.0.6)
     rbtree (0.4.5)
-    regexp_parser (2.1.1)
+    regexp_parser (2.5.0)
     rexml (3.2.5)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -60,17 +60,17 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
-    rubocop (1.19.0)
+    rubocop (1.30.1)
       parallel (~> 1.10)
-      parser (>= 3.0.0.0)
+      parser (>= 3.1.0.0)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
-      rexml
-      rubocop-ast (>= 1.9.1, < 2.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.18.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.10.0)
-      parser (>= 3.0.1.1)
+    rubocop-ast (1.18.0)
+      parser (>= 3.1.1.0)
     rubocop-rspec (2.4.0)
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
@@ -79,7 +79,7 @@ GEM
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
-    unicode-display_width (2.0.0)
+    unicode-display_width (2.1.0)
     zlib (1.1.0)
 
 PLATFORMS
@@ -94,7 +94,7 @@ DEPENDENCIES
   pry
   rake
   rspec
-  rubocop (~> 1.19)
+  rubocop (~> 1.30)
   rubocop-rspec (~> 2.4)
 
 BUNDLED WITH

--- a/freddy.gemspec
+++ b/freddy.gemspec
@@ -22,9 +22,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
 
   spec.add_dependency 'bunny', '~> 2.11'
+  spec.add_dependency 'concurrent-ruby', '~> 1.0'
   spec.add_dependency 'oj', '~> 3.6'
   spec.add_dependency 'opentelemetry-api', '~> 1.0.0.rc3'
   spec.add_dependency 'opentelemetry-semantic_conventions', '~> 1.0'
-  spec.add_dependency 'thread', '~> 0.1'
   spec.add_dependency 'zlib', '~> 1.1'
 end

--- a/freddy.gemspec
+++ b/freddy.gemspec
@@ -12,10 +12,10 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.homepage      = 'https://github.com/salemove/freddy'
   spec.required_ruby_version = '>= 2.7'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler'

--- a/lib/freddy.rb
+++ b/lib/freddy.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'json'
-require 'thread/pool'
+require 'concurrent'
 require 'securerandom'
 require 'opentelemetry'
 require 'opentelemetry/semantic_conventions'
@@ -85,7 +85,7 @@ class Freddy
     handler_adapter_factory = MessageHandlerAdapters::Factory.new(producer)
 
     Consumers::RespondToConsumer.consume(
-      thread_pool: Thread.pool(@prefetch_buffer_size),
+      thread_pool: Concurrent::FixedThreadPool.new(@prefetch_buffer_size),
       destination: destination,
       channel: channel,
       handler_adapter_factory: handler_adapter_factory,
@@ -128,7 +128,7 @@ class Freddy
     @logger.debug "Tapping into messages that match #{pattern_or_patterns}"
 
     Consumers::TapIntoConsumer.consume(
-      thread_pool: Thread.pool(@prefetch_buffer_size),
+      thread_pool: Concurrent::FixedThreadPool.new(@prefetch_buffer_size),
       patterns: Array(pattern_or_patterns),
       channel: @connection.create_channel(prefetch: @prefetch_buffer_size),
       options: options,

--- a/lib/freddy/consumers/respond_to_consumer.rb
+++ b/lib/freddy/consumers/respond_to_consumer.rb
@@ -34,7 +34,7 @@ class Freddy
       end
 
       def process_message(delivery)
-        @consume_thread_pool.process do
+        @consume_thread_pool.post do
           delivery.in_span do
             yield(delivery)
           end

--- a/lib/freddy/consumers/tap_into_consumer.rb
+++ b/lib/freddy/consumers/tap_into_consumer.rb
@@ -46,7 +46,7 @@ class Freddy
       end
 
       def process_message(_queue, delivery)
-        @consume_thread_pool.process do
+        @consume_thread_pool.post do
           delivery.in_span do
             yield delivery.payload, delivery.routing_key
             @channel.acknowledge(delivery.tag)

--- a/lib/freddy/responder_handler.rb
+++ b/lib/freddy/responder_handler.rb
@@ -20,7 +20,8 @@ class Freddy
     #   responder.shutdown
     def shutdown
       @consumer.cancel
-      @consume_thread_pool.wait(:done)
+      @consume_thread_pool.shutdown
+      @consume_thread_pool.wait_for_termination
     end
   end
 end

--- a/lib/freddy/version.rb
+++ b/lib/freddy/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Freddy
-  VERSION = '2.4.0'
+  VERSION = '2.5.0-rc.1'
 end

--- a/spec/freddy/consumers/respond_to_consumer_spec.rb
+++ b/spec/freddy/consumers/respond_to_consumer_spec.rb
@@ -16,7 +16,7 @@ describe Freddy::Consumers::RespondToConsumer do
   let(:msg_handler_adapter_factory) { double(for: msg_handler_adapter) }
   let(:msg_handler_adapter) { Freddy::MessageHandlerAdapters::NoOpHandler.new }
   let(:prefetch_buffer_size) { 2 }
-  let(:thread_pool) { Thread.pool(prefetch_buffer_size) }
+  let(:thread_pool) { Concurrent::FixedThreadPool.new(prefetch_buffer_size) }
 
   after do
     connection.close

--- a/spec/freddy/sync_response_container_spec.rb
+++ b/spec/freddy/sync_response_container_spec.rb
@@ -31,12 +31,13 @@ describe Freddy::SyncResponseContainer do
   describe '#wait_for_response' do
     let(:timeout) { 2 }
     let(:response) { { msg: 'response' } }
-    let(:delivery) { OpenStruct.new(type: 'success') }
 
     context 'when called after #call' do
       let(:max_wait_time_in_seconds) { 0.5 }
 
       before do
+        delivery = instance_double(Freddy::Delivery)
+        allow(delivery).to receive(:type).and_return('success')
         container.call(response, delivery)
       end
 

--- a/spec/integration/tracing_spec.rb
+++ b/spec/integration/tracing_spec.rb
@@ -57,8 +57,8 @@ describe 'Tracing' do
       freddy.deliver_with_response(destination, {})
       names = exporter.finished_spans.map(&:name)
 
-      expect(names.any? { |name| name.include?('amq.gen-') }).to eq(false)
-      expect(names.any? { |name| name.include?('(response queue)') }).to eq(true)
+      expect(names.any? { |name| name.include?('amq.gen-') }).to be(false)
+      expect(names.any? { |name| name.include?('(response queue)') }).to be(true)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,8 +18,6 @@ OpenTelemetry::SDK.configure do |c|
   c.add_span_processor(span_processor)
 end
 
-Thread.abort_on_exception = true
-
 RSpec.configure do |config|
   config.run_all_when_everything_filtered = true
   config.filter_run :focus


### PR DESCRIPTION
This gem depends on depends on gem [thread](https://rubygems.org/gems/thread/versions/0.2.2) which is licensed under WTFPL license. 

That gem is not actively maintained and all of its functionality is included into a well-known gem [concurrent-ruby](https://github.com/ruby-concurrency/concurrent-ruby), which is distributed under MIT license.

Deleting Gemfile.lock, because as it is ignored when installing the gem, the presense of Gemfile.lock is more likely to hide issues with incompatibility with newer versions of dependencies that applications might use.