### PR TITLE
Disable MFA requirement in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -28,3 +28,6 @@ Style/FrozenStringLiteralComment:
 
 Naming/FileName:
   Enabled: no
+
+Gemspec/RequireMFA:
+  Enabled: no

--- a/freddy.gemspec
+++ b/freddy.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
   spec.homepage      = 'https://github.com/salemove/freddy'
   spec.required_ruby_version = '>= 2.7'
-  spec.metadata['rubygems_mfa_required'] = 'true'
 
   spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
Removing MFA requirement for gem publishing and corresponding RuboCop rule to allow auto-publish with GitHub action.