### PR TITLE
Loosen opentelemetry-sdk gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'hamster', '~> 3.0'
-gem 'opentelemetry-sdk', '~> 1.0.0.rc3'
+gem 'opentelemetry-sdk', '~> 1.0'
 gem 'pry'
 gem 'rspec'
 gem 'rubocop', '~> 1.30'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ PATH
       bunny (~> 2.11)
       concurrent-ruby (~> 1.0)
       oj (~> 3.6)
-      opentelemetry-api (~> 1.0.0.rc3)
+      opentelemetry-api (~> 1.0)
       opentelemetry-semantic_conventions (~> 1.0)
       zlib (~> 1.1)
 
@@ -23,19 +23,19 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
-    oj (3.13.14)
-    opentelemetry-api (1.0.0.rc3)
-    opentelemetry-common (0.19.1)
-      opentelemetry-api (~> 1.0.0.rc3)
-    opentelemetry-instrumentation-base (0.18.2)
-      opentelemetry-api (~> 1.0.0.rc3)
-    opentelemetry-sdk (1.0.0.rc3)
-      opentelemetry-api (~> 1.0.0.rc3)
-      opentelemetry-common (~> 0.19.1)
-      opentelemetry-instrumentation-base (~> 0.18.2)
+    oj (3.13.21)
+    opentelemetry-api (1.1.0)
+    opentelemetry-common (0.19.6)
+      opentelemetry-api (~> 1.0)
+    opentelemetry-registry (0.2.0)
+      opentelemetry-api (~> 1.1)
+    opentelemetry-sdk (1.2.0)
+      opentelemetry-api (~> 1.1)
+      opentelemetry-common (~> 0.19.3)
+      opentelemetry-registry (~> 0.2)
       opentelemetry-semantic_conventions
-    opentelemetry-semantic_conventions (1.6.0)
-      opentelemetry-api (~> 1.0.0.rc3)
+    opentelemetry-semantic_conventions (1.8.0)
+      opentelemetry-api (~> 1.0)
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
@@ -75,7 +75,7 @@ GEM
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
-    set (1.0.2)
+    set (1.0.3)
     sorted_set (1.0.3)
       rbtree
       set (~> 1.0)
@@ -90,7 +90,7 @@ DEPENDENCIES
   bundler
   freddy!
   hamster (~> 3.0)
-  opentelemetry-sdk (~> 1.0.0.rc3)
+  opentelemetry-sdk (~> 1.0)
   pry
   rake
   rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    freddy (2.5.0)
+    freddy (2.5.1)
       bunny (~> 2.11)
       concurrent-ruby (~> 1.0)
       oj (~> 3.6)

--- a/freddy.gemspec
+++ b/freddy.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'bunny', '~> 2.11'
   spec.add_dependency 'concurrent-ruby', '~> 1.0'
   spec.add_dependency 'oj', '~> 3.6'
-  spec.add_dependency 'opentelemetry-api', '~> 1.0.0.rc3'
+  spec.add_dependency 'opentelemetry-api', '~> 1.0'
   spec.add_dependency 'opentelemetry-semantic_conventions', '~> 1.0'
   spec.add_dependency 'zlib', '~> 1.1'
 end

--- a/lib/freddy/version.rb
+++ b/lib/freddy/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Freddy
-  VERSION = '2.5.0'
+  VERSION = '2.5.1'
 end


### PR DESCRIPTION
To allow other projects to use newer `opentelemetry-api` version, this
commit loosens the version from `1.0.0rc3` and allows to use any `1.x`
version.

[Changelog][1] doesn't contain any breaking changes.

[1]: https://open-telemetry.github.io/opentelemetry-ruby/opentelemetry-api/v1.1.0/file.CHANGELOG.html