### PR TITLE
Handle keyword argument warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    freddy (2.5.1)
+    freddy (2.6.0)
       bunny (~> 2.11)
       concurrent-ruby (~> 1.0)
       oj (~> 3.6)

--- a/lib/freddy.rb
+++ b/lib/freddy.rb
@@ -85,10 +85,12 @@ class Freddy
     handler_adapter_factory = MessageHandlerAdapters::Factory.new(producer)
 
     Consumers::RespondToConsumer.consume(
-      thread_pool: Concurrent::FixedThreadPool.new(@prefetch_buffer_size),
-      destination: destination,
-      channel: channel,
-      handler_adapter_factory: handler_adapter_factory,
+      **{
+        thread_pool: Concurrent::FixedThreadPool.new(@prefetch_buffer_size),
+        destination: destination,
+        channel: channel,
+        handler_adapter_factory: handler_adapter_factory
+      },
       &callback
     )
   end
@@ -128,10 +130,12 @@ class Freddy
     @logger.debug "Tapping into messages that match #{pattern_or_patterns}"
 
     Consumers::TapIntoConsumer.consume(
-      thread_pool: Concurrent::FixedThreadPool.new(@prefetch_buffer_size),
-      patterns: Array(pattern_or_patterns),
-      channel: @connection.create_channel(prefetch: @prefetch_buffer_size),
-      options: options,
+      **{
+        thread_pool: Concurrent::FixedThreadPool.new(@prefetch_buffer_size),
+        patterns: Array(pattern_or_patterns),
+        channel: @connection.create_channel(prefetch: @prefetch_buffer_size),
+        options: options
+      },
       &callback
     )
   end

--- a/lib/freddy/consumers/respond_to_consumer.rb
+++ b/lib/freddy/consumers/respond_to_consumer.rb
@@ -3,8 +3,8 @@
 class Freddy
   module Consumers
     class RespondToConsumer
-      def self.consume(*attrs, &block)
-        new(*attrs).consume(&block)
+      def self.consume(**attrs, &block)
+        new(**attrs).consume(&block)
       end
 
       def initialize(thread_pool:, destination:, channel:, handler_adapter_factory:)

--- a/lib/freddy/consumers/tap_into_consumer.rb
+++ b/lib/freddy/consumers/tap_into_consumer.rb
@@ -3,8 +3,8 @@
 class Freddy
   module Consumers
     class TapIntoConsumer
-      def self.consume(*attrs, &block)
-        new(*attrs).consume(&block)
+      def self.consume(**attrs, &block)
+        new(**attrs).consume(&block)
       end
 
       def initialize(thread_pool:, patterns:, channel:, options:)

--- a/lib/freddy/version.rb
+++ b/lib/freddy/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Freddy
-  VERSION = '2.5.1'
+  VERSION = '2.6.0'
 end

--- a/spec/freddy/freddy_spec.rb
+++ b/spec/freddy/freddy_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Freddy do
-  let(:freddy) { described_class.build(logger, config) }
+  let(:freddy) { described_class.build(logger, **config) }
 
   let(:destination)  { random_destination }
   let(:destination2) { random_destination }

--- a/spec/freddy/responder_handler_spec.rb
+++ b/spec/freddy/responder_handler_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Freddy::ResponderHandler do
-  let(:freddy) { Freddy.build(logger, config) }
+  let(:freddy) { Freddy.build(logger, **config) }
 
   let(:destination) { random_destination }
   let(:payload)     { { pay: 'load' } }

--- a/spec/integration/concurrency_spec.rb
+++ b/spec/integration/concurrency_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 require 'hamster/experimental/mutable_set'
 
 describe 'Concurrency' do
-  let(:freddy1) { Freddy.build(logger, config) }
-  let(:freddy2) { Freddy.build(logger, config) }
-  let(:freddy3) { Freddy.build(logger, config) }
+  let(:freddy1) { Freddy.build(logger, **config) }
+  let(:freddy2) { Freddy.build(logger, **config) }
+  let(:freddy3) { Freddy.build(logger, **config) }
 
   after { [freddy1, freddy2, freddy3].each(&:close) }
 

--- a/spec/integration/reply_spec.rb
+++ b/spec/integration/reply_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Reply' do
-  let(:freddy) { Freddy.build(logger, config) }
+  let(:freddy) { Freddy.build(logger, **config) }
 
   let(:destination) { random_destination }
   let(:request_payload) { { req: 'load' } }

--- a/spec/integration/tap_into_with_group_spec.rb
+++ b/spec/integration/tap_into_with_group_spec.rb
@@ -2,9 +2,9 @@ require 'spec_helper'
 require 'hamster/experimental/mutable_set'
 
 describe 'Tapping into with group identifier' do
-  let(:deliverer) { Freddy.build(logger, config) }
-  let(:responder1) { Freddy.build(logger, config) }
-  let(:responder2) { Freddy.build(logger, config) }
+  let(:deliverer) { Freddy.build(logger, **config) }
+  let(:responder1) { Freddy.build(logger, **config) }
+  let(:responder2) { Freddy.build(logger, **config) }
 
   let(:destination)  { random_destination }
 

--- a/spec/integration/tracing_spec.rb
+++ b/spec/integration/tracing_spec.rb
@@ -8,8 +8,8 @@ describe 'Tracing' do
   end
 
   context 'when receiving a traced request' do
-    let(:freddy) { Freddy.build(logger, config) }
-    let(:freddy2) { Freddy.build(logger, config) }
+    let(:freddy) { Freddy.build(logger, **config) }
+    let(:freddy2) { Freddy.build(logger, **config) }
 
     let(:destination) { random_destination }
     let(:destination2) { random_destination }
@@ -63,9 +63,9 @@ describe 'Tracing' do
   end
 
   context 'when receiving a nested traced request' do
-    let(:freddy) { Freddy.build(logger, config) }
-    let(:freddy2) { Freddy.build(logger, config) }
-    let(:freddy3) { Freddy.build(logger, config) }
+    let(:freddy) { Freddy.build(logger, **config) }
+    let(:freddy2) { Freddy.build(logger, **config) }
+    let(:freddy3) { Freddy.build(logger, **config) }
 
     let(:destination) { random_destination }
     let(:destination2) { random_destination }


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

> In Ruby 3.0, positional arguments and keyword arguments will be separated.
> Ruby 2.7 will warn for behaviors that will change in Ruby 3.0.
