### PR TITLE
Make exchange name configurable for tap into consumer

### DIFF
--- a/lib/freddy.rb
+++ b/lib/freddy.rb
@@ -120,7 +120,13 @@ class Freddy
   # @option options [String] :exchange_name
   #   Exchange to bind to. Default is `freddy-topic`.
   #
-  # @yield [message] Yields received message to the block
+  # @yield [message] Yields received message to the block.
+  # @yieldparam [Object] payload
+  #   Yields the received message's payload.
+  # @yieldparam [String] routing_key
+  #   Yields the received message's routing key.
+  # @yieldparam [Time] timestamp
+  #   Yields received message's timestamp.
   #
   # @return [#shutdown]
   #

--- a/lib/freddy.rb
+++ b/lib/freddy.rb
@@ -117,6 +117,8 @@ class Freddy
   #   `:ack` simply acknowledges the message and re-raises the exception. `:reject`
   #   rejects the message without requeueing it. `:requeue` rejects the message with
   #   `requeue` flag.
+  # @option options [String] :exchange_name
+  #   Exchange to bind to. Default is `freddy-topic`.
   #
   # @yield [message] Yields received message to the block
   #

--- a/lib/freddy/consumers/tap_into_consumer.rb
+++ b/lib/freddy/consumers/tap_into_consumer.rb
@@ -29,7 +29,7 @@ class Freddy
       private
 
       def create_queue
-        topic_exchange = @channel.topic(Freddy::FREDDY_TOPIC_EXCHANGE_NAME)
+        topic_exchange = @channel.topic(exchange_name)
 
         queue =
           if group
@@ -75,6 +75,10 @@ class Freddy
 
       def on_exception
         @options.fetch(:on_exception, :ack)
+      end
+
+      def exchange_name
+        @options.fetch(:exchange_name, Freddy::FREDDY_TOPIC_EXCHANGE_NAME)
       end
     end
   end

--- a/lib/freddy/consumers/tap_into_consumer.rb
+++ b/lib/freddy/consumers/tap_into_consumer.rb
@@ -48,7 +48,7 @@ class Freddy
       def process_message(_queue, delivery)
         @consume_thread_pool.post do
           delivery.in_span do
-            yield delivery.payload, delivery.routing_key
+            yield delivery.payload, delivery.routing_key, delivery.timestamp
             @channel.acknowledge(delivery.tag)
           end
         rescue StandardError

--- a/lib/freddy/delivery.rb
+++ b/lib/freddy/delivery.rb
@@ -24,6 +24,10 @@ class Freddy
       @metadata.reply_to
     end
 
+    def timestamp
+      @metadata[:timestamp]
+    end
+
     def in_span(&block)
       name = "#{Tracing.span_destination(@exchange, @routing_key)} process"
       kind = OpenTelemetry::Trace::SpanKind::CONSUMER

--- a/spec/integration/tap_into_with_exchange_spec.rb
+++ b/spec/integration/tap_into_with_exchange_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe 'Tapping into with exchange identifier' do
+  let(:freddy) { Freddy.build(logger, **config) }
+
+  let(:connection) { Freddy::Adapters.determine.connect(config) }
+  let(:topic) { 'test_topic_exchange' }
+  let(:channel) { connection.create_channel }
+  let(:message_payload) { { test: 'test' }.to_json }
+  let(:expected_payload) { { test: 'test' } }
+  let(:publish_timestamp) { Time.now.to_i }
+
+  after do
+    connection.close
+    freddy.close
+  end
+
+  it 'receives message' do
+    freddy.tap_into('pattern.*', exchange_name: topic) do |payload, _routing_key, timestamp|
+      @received_payload = payload
+      @received_timestamp = timestamp
+    end
+
+    channel.topic(topic).publish(message_payload, { routing_key: 'pattern.random', timestamp: publish_timestamp })
+
+    wait_for { @received_payload }
+    wait_for { @received_timestamp }
+
+    expect(@received_payload).to eq(expected_payload)
+    expect(@received_timestamp.to_i).to eq(publish_timestamp)
+  end
+
+  it 'receives message with nil timestamp when timestamp is not published' do
+    received_timestamp = 0
+    freddy.tap_into('pattern.*', exchange_name: topic) do |_payload, _routing_key, timestamp|
+      received_timestamp = timestamp
+    end
+
+    channel.topic(topic).publish(message_payload, { routing_key: 'pattern.random' })
+    default_sleep
+
+    expect(received_timestamp).to eq(nil)
+  end
+end


### PR DESCRIPTION
* Make exchange name configurable for tap_into listener.
> The messages can only be heard from the `freddy-topic` exchange.
> This commit makes the it possible to listen to messages from different exchange
> by defining `exchange_name` option's parameter.'

* Make delivery timestamp available for tap into the consumer.
> The timestamp is necessary for some applications that need an event start time.
> It defaults to nil if the message timestamp doesn't exit.