### PR TITLE
Support custom headers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    freddy (2.7.0)
+    freddy (2.8.0)
       bunny (~> 2.11)
       concurrent-ruby (~> 1.0)
       oj (~> 3.6)

--- a/README.md
+++ b/README.md
@@ -55,6 +55,11 @@ The message heading specify the `content-encoding` indicating the compression al
 freddy.deliver(destination, message, compress: 'zlib')
 ```
 
+#### Metadata through headers
+
+Send a message with arbitrary message metadata included in the message headers
+freddy.deliver(destination, message, headers: {'my-key' => 'my-value'})
+
 ### Request delivery
 
 #### Expiring messages

--- a/lib/freddy.rb
+++ b/lib/freddy.rb
@@ -166,6 +166,8 @@ class Freddy
   #   won't be discarded if timeout it set to 0 (default).
   # @option options [String] :compress (nil)
   #   - 'zlib' - compresses the payload with zlib
+  # @option options [Hash] :headers (nil)
+  #   Arbitrary headers to add as message metadata
   # @return [void]
   #
   # @example
@@ -176,6 +178,7 @@ class Freddy
     opts = {}
     opts[:expiration] = (timeout * 1000).to_i if timeout.positive?
     opts[:content_encoding] = compression_algorithm if compression_algorithm
+    opts[:headers] = options[:headers] if options[:headers]
 
     @send_and_forget_producer.produce(destination, payload, opts)
   end

--- a/lib/freddy/version.rb
+++ b/lib/freddy/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class Freddy
-  VERSION = '2.7.0'
+  VERSION = '2.8.0'
 end

--- a/spec/freddy/freddy_spec.rb
+++ b/spec/freddy/freddy_spec.rb
@@ -9,12 +9,13 @@ describe Freddy do
 
   before do
     @bunny = Bunny.new(config)
-    @bunny.start()
+    @bunny.start
   end
 
-  after { @bunny.close }
-
-  after { freddy.close }
+  after do
+    @bunny.close
+    freddy.close
+  end
 
   def respond_to(&block)
     freddy.respond_to(destination, &block)
@@ -81,13 +82,14 @@ describe Freddy do
     end
 
     it 'accepts custom headers' do
+      headers = nil
       queue = exclusive_subscribe do |_info, metadata, _payload|
-        @metadata = metadata
+        headers = metadata[:headers]
       end
-      freddy.deliver(queue, payload, headers: {'foo' => 'bar'})
+      freddy.deliver(queue, payload, headers: { 'foo' => 'bar' })
 
-      wait_for { @metadata }
-      expect(@metadata[:headers]).to include({'foo' => 'bar'})
+      wait_for { headers }
+      expect(headers).to include({ 'foo' => 'bar' })
     end
   end
 


### PR DESCRIPTION
Headers are the main point for including message metadata in AMQP.
Headers are already in use to propagate traces.
Allow library users to add arbitrary headers themselves.